### PR TITLE
Fixed: Success Message shouldn't be shown to non-admin users.

### DIFF
--- a/src/Frontend/Process.php
+++ b/src/Frontend/Process.php
@@ -764,7 +764,7 @@ class Process {
 	 * @return string
 	 */
 	public function add_success_message( $html ) {
-		if ( ! isset( $_GET[ 'omgf_optimize' ] ) || wp_doing_ajax() ) {
+		if ( ! isset( $_GET[ 'omgf_optimize' ] ) || wp_doing_ajax() || ! current_user_can( 'manage_options' ) ) {
 			return $html;
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Success messages are now only displayed to users with administrative privileges. Non-admin users will no longer see these messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->