### PR TITLE
Fixed some PHP 8.3 deprecated warnings when using Unload feature on Elementor stylesheets.

### DIFF
--- a/src/Frontend/Process.php
+++ b/src/Frontend/Process.php
@@ -637,9 +637,13 @@ class Process {
 			/**
 			 * @since v5.3.7 decode URL and special HTML chars, to make sure all params are properly processed later on.
 			 */
-			$href  = urldecode( htmlspecialchars_decode( $stack[ 'href' ] ) );
-			$query = wp_parse_url( $href, PHP_URL_QUERY );
-			parse_str( $query, $query );
+			$href         = urldecode( htmlspecialchars_decode( $stack[ 'href' ] ) );
+			$parsed_query = wp_parse_url( $href, PHP_URL_QUERY );
+			$query        = [];
+
+			if ( $parsed_query ) {
+				parse_str( $parsed_query, $query );
+			}
 
 			/**
 			 * If required parameters aren't set, this request is most likely invalid. Let's just remove it.

--- a/src/Optimize.php
+++ b/src/Optimize.php
@@ -580,9 +580,12 @@ class Optimize {
 	 * @return string     Full request (excluding unloaded variants)
 	 */
 	private function unload_css( $url ) {
-		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		$query         = wp_parse_url( $url, PHP_URL_QUERY );
+		$font_families = [];
 
-		parse_str( $query, $font_families );
+		if ( $query ) {
+			parse_str( $query, $font_families );
+		}
 
 		foreach ( $font_families = explode( '|', $font_families[ 'family' ] ) as $key => $font_family ) {
 			[ $name, $tuples ] = array_pad( explode( ':', $font_family ), 2, [] );

--- a/src/Optimize.php
+++ b/src/Optimize.php
@@ -587,7 +587,11 @@ class Optimize {
 			parse_str( $query, $font_families );
 		}
 
-		foreach ( $font_families = explode( '|', $font_families[ 'family' ] ) as $key => $font_family ) {
+		if ( ! empty( $font_families[ 'family' ] ) ) {
+			$font_families = explode( '|', $font_families[ 'family' ] );
+		}
+
+		foreach ( $font_families as $key => $font_family ) {
 			[ $name, $tuples ] = array_pad( explode( ':', $font_family ), 2, [] );
 
 			$id = str_replace( ' ', '-', strtolower( $name ) );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of URLs without query parameters to prevent potential errors during processing.
  * Enhanced robustness when parsing Google Fonts URLs, ensuring safer handling when query strings are missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->