### PR TITLE
Fixed: Google Fonts and Performance Checker didn't run when Disable Admin Bar Menu was enabled.

### DIFF
--- a/assets/js/omgf-frontend.js
+++ b/assets/js/omgf-frontend.js
@@ -78,14 +78,12 @@ window.addEventListener('load', () => {
 				status = response.status || null;
 
 				// menu_item only exists if the logged-in user has the manage_options cap.
-				if (this.menu_item === null) {
-					return;
-				}
+				if (this.menu_item !== null) {
+					this.menu_item.classList.add('dot');
 
-				this.menu_item.classList.add('dot');
-
-				if (status) {
-					this.menu_item.classList.add(status);
+					if (status) {
+						this.menu_item.classList.add(status);
+					}
 				}
 
 				if ((status !== 'success' && status !== 'warning') && this.sub_menu !== null) {

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -94,7 +94,7 @@ class Filters {
 	 * Don't load frontend assets if the Disable Admin Bar Menu option is enabled.
 	 *
 	 * @filter omgf_do_not_load_frontend_assets
-	 * @see    Frontend\Actions::maybe_add_admin_bar_css()
+	 * @see    Frontend\Actions::maybe_add_admin_bar_assets()
 	 *
 	 * @since  v6.0.1
 	 *

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -94,7 +94,7 @@ class Filters {
 	 * Don't load frontend assets if the Disable Admin Bar Menu option is enabled.
 	 *
 	 * @filter omgf_do_not_load_frontend_assets
-	 * @see    Frontend\Actions::maybe_add_frontend_assets()
+	 * @see    Frontend\Actions::maybe_add_admin_bar_css()
 	 *
 	 * @since  v6.0.1
 	 *

--- a/src/Frontend/Actions.php
+++ b/src/Frontend/Actions.php
@@ -29,7 +29,7 @@ class Actions {
 	public function __construct() {
 		add_action( 'init', [ $this, 'init_frontend' ], 50 );
 		add_action( 'admin_bar_menu', [ $this, 'add_admin_bar_item' ], 1000 );
-		add_action( 'wp_enqueue_scripts', [ $this, 'maybe_add_frontend_assets' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'maybe_add_admin_bar_assets' ] );
 	}
 
 	/**
@@ -105,8 +105,8 @@ class Actions {
 	 *
 	 * @return void
 	 */
-	public function maybe_add_frontend_assets() {
-		if ( apply_filters( 'omgf_do_not_load_frontend_assets', ! current_user_can( 'manage_options' ) ) ) {
+	public function maybe_add_admin_bar_assets() {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 
@@ -150,7 +150,7 @@ class Actions {
 		wp_enqueue_script( self::FRONTEND_ASSET_HANDLE );
 
 		// Even if the above filter forces the JS to load, we'll only need the CSS if the current user is an admin.
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( apply_filters( 'omgf_do_not_load_frontend_assets', ! current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
 

--- a/tests/integration/Frontend/ActionsTest.php
+++ b/tests/integration/Frontend/ActionsTest.php
@@ -148,6 +148,7 @@ class ActionsTest extends TestCase {
 			$this->assertTrue( wp_style_is( 'omgf-frontend', 'enqueued' ) );
 		} finally {
 			remove_filter( 'omgf_setting_disable_quick_access', '__return_true' );
+			remove_filter( 'omgf_do_not_load_frontend_assets', '__return_false', 11 );
 			wp_dequeue_script( 'omgf-frontend' );
 			wp_dequeue_style( 'omgf-frontend' );
 		}
@@ -164,6 +165,8 @@ class ActionsTest extends TestCase {
 	public function testAddFrontendAssetsWithDisableQuickAccessEnabled() {
 		global $current_user;
 
+		$old_current_user = $current_user;
+
 		try {
 			$current_user = new \WP_User( 1 );
 			$current_user->set_role( 'administrator' );
@@ -176,7 +179,7 @@ class ActionsTest extends TestCase {
 
 			$class->maybe_add_admin_bar_assets();
 
-			$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
+			$this->assertTrue( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
 		} finally {
 			remove_filter( 'omgf_setting_disable_quick_access', '__return_true' );
@@ -184,8 +187,12 @@ class ActionsTest extends TestCase {
 			wp_dequeue_style( 'omgf-frontend' );
 		}
 
-		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
-		$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
+		try {
+			$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
+			$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
+		} finally {
+			$current_user = $old_current_user;
+		}
 	}
 
 	/**

--- a/tests/integration/Frontend/ActionsTest.php
+++ b/tests/integration/Frontend/ActionsTest.php
@@ -13,18 +13,6 @@ use OMGF\Tests\TestCase;
 
 class ActionsTest extends TestCase {
 	/**
-	 * @see Actions::init_frontend()
-	 * @return void
-	 */
-	public function testInitFrontend() {
-		new Actions();
-
-		do_action( 'init' );
-
-		$this->assertTrue( class_exists( '\OMGF\Frontend\Process' ) );
-	}
-
-	/**
 	 * @see Actions::add_admin_bar_item()
 	 * @return void
 	 */
@@ -48,26 +36,6 @@ class ActionsTest extends TestCase {
 		} finally {
 			$current_user = null;
 		}
-	}
-
-	/**
-	 * This is not an admin user. No menu item should be added.
-	 *
-	 * @return void
-	 */
-	public function testAddAdminBarItemWithNoUser() {
-		$class     = new Actions();
-		$admin_bar = new \WP_Admin_Bar();
-
-		$class->add_admin_bar_item( $admin_bar );
-
-		$nodes = $admin_bar->get_nodes();
-
-		if ( empty( $nodes ) ) {
-			$nodes = [];
-		}
-
-		$this->assertCount( 0, $nodes );
 	}
 
 	/**
@@ -104,7 +72,27 @@ class ActionsTest extends TestCase {
 	}
 
 	/**
-	 * @see Actions::maybe_add_frontend_assets()
+	 * This is not an admin user. No menu item should be added.
+	 *
+	 * @return void
+	 */
+	public function testAddAdminBarItemWithNoUser() {
+		$class     = new Actions();
+		$admin_bar = new \WP_Admin_Bar();
+
+		$class->add_admin_bar_item( $admin_bar );
+
+		$nodes = $admin_bar->get_nodes();
+
+		if ( empty( $nodes ) ) {
+			$nodes = [];
+		}
+
+		$this->assertCount( 0, $nodes );
+	}
+
+	/**
+	 * @see Actions::maybe_add_admin_bar_css()
 	 *
 	 *
 	 * @return void
@@ -118,7 +106,7 @@ class ActionsTest extends TestCase {
 
 			$class = new Actions();
 
-			$class->maybe_add_frontend_assets();
+			$class->maybe_add_admin_bar_css();
 
 			$this->assertTrue( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertTrue( wp_style_is( 'omgf-frontend', 'enqueued' ) );
@@ -126,38 +114,6 @@ class ActionsTest extends TestCase {
 			wp_dequeue_script( 'omgf-frontend' );
 			wp_dequeue_style( 'omgf-frontend' );
 			$current_user = null;
-		}
-
-		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
-		$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
-	}
-
-	/**
-	 * When Disable Quick Access is enabled, the frontend assets should not be enqueued.
-	 *
-	 * @return void
-	 */
-	public function testAddFrontendAssetsWithDisableQuickAccessEnabled() {
-		global $current_user;
-
-		try {
-			$current_user = new \WP_User( 1 );
-			$current_user->set_role( 'administrator' );
-
-			$class = new Actions();
-
-			add_filter( 'omgf_setting_disable_quick_access', '__return_true' );
-
-			new Filters();
-
-			$class->maybe_add_frontend_assets();
-
-			$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
-			$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
-		} finally {
-			remove_filter( 'omgf_setting_disable_quick_access', '__return_true' );
-			wp_dequeue_script( 'omgf-frontend' );
-			wp_dequeue_style( 'omgf-frontend' );
 		}
 
 		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
@@ -186,7 +142,7 @@ class ActionsTest extends TestCase {
 			// OMGF Pro's Google Fonts Checker overwrites all other filters by running last.
 			add_filter( 'omgf_do_not_load_frontend_assets', '__return_false', 11 );
 
-			$class->maybe_add_frontend_assets();
+			$class->maybe_add_admin_bar_css();
 
 			$this->assertTrue( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertTrue( wp_style_is( 'omgf-frontend', 'enqueued' ) );
@@ -198,5 +154,49 @@ class ActionsTest extends TestCase {
 
 		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 		$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
+	}
+
+	/**
+	 * When Disable Quick Access is enabled, the frontend assets should not be enqueued.
+	 *
+	 * @return void
+	 */
+	public function testAddFrontendAssetsWithDisableQuickAccessEnabled() {
+		global $current_user;
+
+		try {
+			$current_user = new \WP_User( 1 );
+			$current_user->set_role( 'administrator' );
+
+			$class = new Actions();
+
+			add_filter( 'omgf_setting_disable_quick_access', '__return_true' );
+
+			new Filters();
+
+			$class->maybe_add_admin_bar_css();
+
+			$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
+			$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
+		} finally {
+			remove_filter( 'omgf_setting_disable_quick_access', '__return_true' );
+			wp_dequeue_script( 'omgf-frontend' );
+			wp_dequeue_style( 'omgf-frontend' );
+		}
+
+		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );
+	}
+
+	/**
+	 * @see Actions::init_frontend()
+	 * @return void
+	 */
+	public function testInitFrontend() {
+		new Actions();
+
+		do_action( 'init' );
+
+		$this->assertTrue( class_exists( '\OMGF\Frontend\Process' ) );
 	}
 }

--- a/tests/integration/Frontend/ActionsTest.php
+++ b/tests/integration/Frontend/ActionsTest.php
@@ -17,8 +17,11 @@ class ActionsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAddAdminBarItem() {
+		global $current_user;
+
+		$old_current_user = $current_user;
+
 		try {
-			global $current_user;
 
 			$current_user = new \WP_User( 1 );
 			$current_user->set_role( 'administrator' );
@@ -34,7 +37,7 @@ class ActionsTest extends TestCase {
 
 			$this->assertCount( 2, $nodes );
 		} finally {
-			$current_user = null;
+			$current_user = $old_current_user;
 		}
 	}
 
@@ -46,6 +49,8 @@ class ActionsTest extends TestCase {
 	 */
 	public function testAddAdminBarItemWhenDisableQuickAccessEnabled() {
 		global $current_user;
+
+		$old_current_user = $current_user;
 
 		try {
 			$current_user = new \WP_User( 1 );
@@ -67,7 +72,8 @@ class ActionsTest extends TestCase {
 			$this->assertCount( 0, $nodes );
 		} finally {
 			remove_filter( 'omgf_setting_disable_quick_access', '__return_true' );
-			$current_user = null;
+
+			$current_user = $old_current_user;
 		}
 	}
 
@@ -100,6 +106,8 @@ class ActionsTest extends TestCase {
 	public function testAddFrontendAssetsDefault() {
 		global $current_user;
 
+		$old_current_user = $current_user;
+
 		try {
 			$current_user = new \WP_User( 1 );
 			$current_user->set_role( 'administrator' );
@@ -113,7 +121,7 @@ class ActionsTest extends TestCase {
 		} finally {
 			wp_dequeue_script( 'omgf-frontend' );
 			wp_dequeue_style( 'omgf-frontend' );
-			$current_user = null;
+			$current_user = $old_current_user;
 		}
 
 		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
@@ -129,6 +137,8 @@ class ActionsTest extends TestCase {
 	public function testAddFrontendAssetsWithDisableQuickAccessAndGFCEnabled() {
 		try {
 			global $current_user;
+
+			$old_current_user = $current_user;
 
 			$current_user = new \WP_User( 1 );
 			$current_user->set_role( 'administrator' );
@@ -151,6 +161,7 @@ class ActionsTest extends TestCase {
 			remove_filter( 'omgf_do_not_load_frontend_assets', '__return_false', 11 );
 			wp_dequeue_script( 'omgf-frontend' );
 			wp_dequeue_style( 'omgf-frontend' );
+			$current_user = $old_current_user;
 		}
 
 		$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );

--- a/tests/integration/Frontend/ActionsTest.php
+++ b/tests/integration/Frontend/ActionsTest.php
@@ -92,7 +92,7 @@ class ActionsTest extends TestCase {
 	}
 
 	/**
-	 * @see Actions::maybe_add_admin_bar_css()
+	 * @see Actions::maybe_add_admin_bar_assets()
 	 *
 	 *
 	 * @return void
@@ -106,7 +106,7 @@ class ActionsTest extends TestCase {
 
 			$class = new Actions();
 
-			$class->maybe_add_admin_bar_css();
+			$class->maybe_add_admin_bar_assets();
 
 			$this->assertTrue( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertTrue( wp_style_is( 'omgf-frontend', 'enqueued' ) );
@@ -142,7 +142,7 @@ class ActionsTest extends TestCase {
 			// OMGF Pro's Google Fonts Checker overwrites all other filters by running last.
 			add_filter( 'omgf_do_not_load_frontend_assets', '__return_false', 11 );
 
-			$class->maybe_add_admin_bar_css();
+			$class->maybe_add_admin_bar_assets();
 
 			$this->assertTrue( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertTrue( wp_style_is( 'omgf-frontend', 'enqueued' ) );
@@ -174,7 +174,7 @@ class ActionsTest extends TestCase {
 
 			new Filters();
 
-			$class->maybe_add_admin_bar_css();
+			$class->maybe_add_admin_bar_assets();
 
 			$this->assertFalse( wp_script_is( 'omgf-frontend', 'enqueued' ) );
 			$this->assertFalse( wp_style_is( 'omgf-frontend', 'enqueued' ) );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin bar menu item handling for more resilient initialization in the frontend script.

* **New Features**
  * Added a customization filter to control frontend asset loading.
  * Separated admin-bar asset loading path to isolate admin-bar assets.

* **Tests**
  * Expanded integration tests covering admin-bar and frontend asset scenarios, including disable-quick-access and checker combinations.

* **Documentation**
  * Updated PHPDoc reference links for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->