### PR TITLE
Improved: settings save handler no longer stores a malformed (scalar) value for options that must be arrays.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,9 @@ For the FAQ, [click here](https://daan.dev/docs/omgf-pro-faq/).
 
 == Changelog ==
 
+= 6.3.9 =
+* Fixed: The settings save handler no longer stores a malformed (scalar) value for options that must be arrays (e.g. when a proxy or security plugin flattens the array parameters), and self-heals a previously corrupted option on the next save. This prevents a fatal 'Cannot access offset of type string on string' error on the Optimize Fonts screen. Add-ons can register their own array-based options via the omgf_settings_array_options filter.
+
 = 6.3.8 | June 25th, 2026 =
 * XSS: Hardened security by adding capability and nonce checks to Save & Optimize action.
 

--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -79,8 +79,32 @@ class Actions {
 
 		$updated_settings = $this->clean( $_POST );
 
+		/**
+		 * These options are always stored as (nested) arrays, keyed by font handle. A scalar value for
+		 * any of them means the request was malformed, e.g. a proxy or security plugin that flattened
+		 * the array parameters (foo[a][b]=x => foo=x). Persisting the scalar corrupts the option and,
+		 * because the read side subscripts it by handle, triggers a fatal
+		 * "Cannot access offset of type string on string" on PHP 8+ the next time the settings screen
+		 * is rendered. A reset ('0') is handled separately below and is always allowed.
+		 *
+		 * @filter omgf_settings_array_options
+		 */
+		$array_options = apply_filters(
+			'omgf_settings_array_options',
+			[
+				Settings::OMGF_OPTIMIZE_SETTING_PRELOAD_FONTS,
+				Settings::OMGF_OPTIMIZE_SETTING_UNLOAD_FONTS,
+			]
+		);
+
 		foreach ( $updated_settings as $option_name => $option_value ) {
 			if ( ! str_starts_with( $option_name, 'omgf_' ) || ( empty( $option_value ) && $option_value !== '0' ) ) {
+				continue;
+			}
+
+			// Ignore a malformed (non-array, non-reset) value for an option that must be an array,
+			// rather than overwriting the existing, valid setting with corrupt data.
+			if ( $option_value !== '0' && ! is_array( $option_value ) && in_array( $option_name, $array_options, true ) ) {
 				continue;
 			}
 
@@ -90,13 +114,20 @@ class Actions {
 				}
 			}
 
-			if ( is_string( $option_value ) && $option_value !== '0' ) {
-				$merged = $option_value;
-			} elseif ( $option_value === '0' ) {
+			if ( $option_value === '0' ) {
 				$merged = [];
+			} elseif ( is_string( $option_value ) ) {
+				$merged = $option_value;
 			} else {
-				$current_options = ! empty( OMGF::get_option( $option_name, [] ) ) ? OMGF::get_option( $option_name ) : [];
-				$merged          = array_replace( $current_options, $option_value );
+				$current_options = OMGF::get_option( $option_name, [] );
+
+				// Coerce a previously corrupted (non-array) value back to an array, so a valid save
+				// self-heals the option instead of throwing a TypeError in array_replace().
+				if ( ! is_array( $current_options ) ) {
+					$current_options = [];
+				}
+
+				$merged = array_replace( $current_options, $option_value );
 			}
 
 			OMGF::update_option( $option_name, $merged );

--- a/tests/integration/Admin/ActionsTest.php
+++ b/tests/integration/Admin/ActionsTest.php
@@ -53,6 +53,51 @@ class ActionsTest extends TestCase {
 	}
 
 	/**
+	 * A malformed (scalar) value for an option that must be a nested array - e.g. when a proxy or
+	 * security plugin flattens the array parameters - must be ignored, leaving the existing valid
+	 * setting untouched instead of corrupting it.
+	 *
+	 * @see Actions::update_settings()
+	 * @return void
+	 */
+	public function testUpdateSettingsIgnoresMalformedScalarForArrayOption() {
+		$existing = [ 'handle-1' => [ 'open-sans' => [ 'normal' => 'on' ] ] ];
+
+		OMGF::update_option( 'omgf_preload_fonts', $existing );
+
+		$_POST                        = [];
+		$_POST[ '_wpnonce' ]          = wp_create_nonce( 'omgf-optimize-settings-options' );
+		$_POST[ 'action' ]            = 'omgf-update';
+		$_POST[ 'omgf_preload_fonts' ] = 'on'; // Flattened array parameter.
+
+		( new Actions() )->update_settings();
+
+		$this->assertSame( $existing, OMGF::get_option( 'omgf_preload_fonts' ) );
+	}
+
+	/**
+	 * A valid save must overwrite a previously corrupted (string) value instead of throwing a
+	 * TypeError in array_replace(), so the option self-heals.
+	 *
+	 * @see Actions::update_settings()
+	 * @return void
+	 */
+	public function testUpdateSettingsSelfHealsCorruptedArrayOption() {
+		OMGF::update_option( 'omgf_unload_fonts', 'this-is-not-an-array' );
+
+		$expected = [ 'handle-1' => [ 'open-sans' => [ 'normal' => 'on' ] ] ];
+
+		$_POST                       = [];
+		$_POST[ '_wpnonce' ]         = wp_create_nonce( 'omgf-optimize-settings-options' );
+		$_POST[ 'action' ]           = 'omgf-update';
+		$_POST[ 'omgf_unload_fonts' ] = $expected;
+
+		( new Actions() )->update_settings();
+
+		$this->assertSame( $expected, OMGF::get_option( 'omgf_unload_fonts' ) );
+	}
+
+	/**
 	 * @see Actions::clean_stale_cache()
 	 * @return void
 	 */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented malformed scalar values from corrupting settings that require array-based data.
  * Automatically repairs previously corrupted settings when valid values are saved.
  * Resolved a fatal error that could occur when opening the “Optimize Fonts” screen.
  * Added support for extending recognized array-based settings through an add-on filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->